### PR TITLE
Feature/ovitrampa

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 *.pyc
 *.html
-.RData
-.Rhistory
+*.RData
+*.Rhistory
 GeraAlerta/figure/*.*
 *.png
 *.pdf

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 .RData
 .Rhistory
 GeraAlerta/figure/*.*
-*,png
+*.png
 *.pdf
+*~

--- a/GeraAlerta/atualiza_alerta.r
+++ b/GeraAlerta/atualiza_alerta.r
@@ -37,8 +37,9 @@ source("organizaDados/organizasinan.r")
 source("organizaDados/juntaTudo.r")
 
 # A5. Dados das ovitrampas (ainda nao integrado ao resto)
+# dec="," pois o arquivo bruto utiliza vírgula como separador decimal.
 ovifile <- "dados_brutos/ovitrampa/IPOMar2015.csv"
-ovi<-read.csv(ovifile,sep=";")
+ovi<-read.csv(ovifile,sep=";",dec=",")
 
 # =======================================
 # B. Alerta: Para ajustar o modelo de alerta:


### PR DESCRIPTION
Updates to .gitignore and atualiza_alerta.r:
- atualiza_alerta.r:
Changed ovitrampa data loader, to recognize "," as decimal separator, as used in the raw data file.
Alternatively, it can be used read.csv2(<file>) instead of read.csv(<file>, sep=";", dec=",").
csv2 assumes "European" defaults for csv files, while csv assumes "USA" defaults. This change is so that the IPO column is read as float, instead of string. The major impact is in the report's ovitrampa graph.

- .gitignore:
*.png (was misspeled)
*~
*.RData
*.Rhistory

